### PR TITLE
switch download implementation using GetObject instead of downloader

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,19 @@
   "version": "0.2.0",
   "configurations": [
       {
+          "name": "Launch Package",
+          "type": "go",
+          "request": "launch",
+          "mode": "debug",
+          "program": "${workspaceFolder}",
+          "env": {
+            "S3_ACCESS_KEY": "F6WUUG27HBUFSIXVZL59",
+            "S3_SECRET_KEY": "BPlIUU6SX0ZxiCMo3tIpCMAUdnmkN9Eo9K42NsRR",
+            "S3_ENDPOINT": "http://127.0.0.1:9000",
+            "TCP_PORT": "8082"
+        }
+      },
+      {
           "name": "Launch test package",
           "type": "go",
           "request": "launch",
@@ -15,20 +28,6 @@
               "S3_SECRET_KEY": "BPlIUU6SX0ZxiCMo3tIpCMAUdnmkN9Eo9K42NsRR",
               "S3_ENDPOINT": "http://127.0.0.1:9000",
           }
-      },
-      {
-          "name": "Launch",
-          "type": "go",
-          "request": "launch",
-          "mode": "auto",
-          "program": "${fileDirname}",
-          "env": {
-              "S3_ACCESS_KEY": "F6WUUG27HBUFSIXVZL59",
-              "S3_SECRET_KEY": "BPlIUU6SX0ZxiCMo3tIpCMAUdnmkN9Eo9K42NsRR",
-              "S3_ENDPOINT": "http://minio:9000",
-              "TCP_PORT": "8080"
-          },
-          "args": []
       }
   ]
 }

--- a/download.go
+++ b/download.go
@@ -1,16 +1,16 @@
 package main
 
 import (
+	"io/ioutil"
 	pb "download-service/proto"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
 const (
-	chunkSize int64 = 5 << 20 // 5MB per part
+	partSize int64 = 5 << 20 // 5MB per part
 )
 
 // DownloadService is a structure used for downloading files from S3
@@ -22,11 +22,6 @@ type DownloadService struct {
 // It recieves a req for a file.
 // Responds with a stream of the file bytes in chunks.
 func (s DownloadService) Download(req *pb.DownloadRequest, stream pb.Download_DownloadServer) error {
-	// Initialize downloader from client.
-	downloader := s3manager.NewDownloaderWithClient(s.s3Client, func(d *s3manager.Downloader) {
-		d.PartSize = chunkSize
-	})
-
 	// fetch key and bucket from the request and check it's validity.
 	key := req.GetKey()
 	bucket := req.GetBucket()
@@ -50,25 +45,37 @@ func (s DownloadService) Download(req *pb.DownloadRequest, stream pb.Download_Do
 	}
 
 	// Calculate how many parts there are to download.
-	totalParts := *fileDetails.ContentLength / downloader.PartSize
-	if *fileDetails.ContentLength%downloader.PartSize > 0 {
+	totalParts := *fileDetails.ContentLength / partSize
+	if *fileDetails.ContentLength % partSize > 0 {
 		totalParts++
 	}
 
 	// Iterate over all of the parts, download each part and stream it to the client.
-	for currentPart := int64(1); currentPart <= totalParts; currentPart++ {
-		buf := aws.NewWriteAtBuffer(make([]byte, 0, int(downloader.PartSize)))
-		_, err := downloader.DownloadWithContext(
-			stream.Context(),
-			buf,
-			&s3.GetObjectInput{Key: aws.String(key), Bucket: aws.String(bucket), PartNumber: aws.Int64(currentPart)},
-		)
+	for currentPart := int64(0); currentPart < totalParts; currentPart++ {
+		rangeStart := currentPart * partSize
+		rangeEnd := rangeStart + partSize - 1
+		if rangeEnd > *fileDetails.ContentLength {
+			rangeEnd = *fileDetails.ContentLength - 1
+		}
 
+		getObjectInput := &s3.GetObjectInput{
+			Key: aws.String(key),
+			Bucket: aws.String(bucket),
+			PartNumber: aws.Int64(currentPart),
+			Range: aws.String(fmt.Sprintf("bytes=%d-%d", rangeStart, rangeEnd)),
+		}
+
+		objectPartOutput, err := s.s3Client.GetObjectWithContext(stream.Context(), getObjectInput)
 		if err != nil {
 			return fmt.Errorf("failed to download file from %s/%s: %v", bucket, key, err)
 		}
 
-		stream.Send(&pb.DownloadResponse{File: buf.Bytes()})
+		partBytes, err := ioutil.ReadAll(objectPartOutput.Body)
+		if err != nil {
+			return fmt.Errorf("failed to download part %d: %v", currentPart, err)
+		}
+
+		stream.Send(&pb.DownloadResponse{File: partBytes})
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/aws/aws-sdk-go v1.19.2
 	github.com/golang/protobuf v1.3.1
+	github.com/meateam/download-service v0.0.0-20190414150718-bd5818b1d581
 	golang.org/x/net v0.0.0-20190327025741-74e053c68e29
 	google.golang.org/grpc v1.19.1
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/meateam/download-service v0.0.0-20190414150718-bd5818b1d581 h1:g9D4Hxvsik/3Lkbq3YvHJnZQFerbfJsyIynofwwJtZI=
+github.com/meateam/download-service v0.0.0-20190414150718-bd5818b1d581/go.mod h1:UiatC7w4geyKhAGyWqpFYDf4VpB2wM/oon+cgPzkr0s=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/proto/download_service.pb.go
+++ b/proto/download_service.pb.go
@@ -38,7 +38,7 @@ func (m *DownloadRequest) Reset()         { *m = DownloadRequest{} }
 func (m *DownloadRequest) String() string { return proto.CompactTextString(m) }
 func (*DownloadRequest) ProtoMessage()    {}
 func (*DownloadRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_download_service_27a97b505d50aaec, []int{0}
+	return fileDescriptor_download_service_9db8895138dec550, []int{0}
 }
 func (m *DownloadRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DownloadRequest.Unmarshal(m, b)
@@ -85,7 +85,7 @@ func (m *DownloadResponse) Reset()         { *m = DownloadResponse{} }
 func (m *DownloadResponse) String() string { return proto.CompactTextString(m) }
 func (*DownloadResponse) ProtoMessage()    {}
 func (*DownloadResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_download_service_27a97b505d50aaec, []int{1}
+	return fileDescriptor_download_service_9db8895138dec550, []int{1}
 }
 func (m *DownloadResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DownloadResponse.Unmarshal(m, b)
@@ -217,10 +217,10 @@ var _Download_serviceDesc = grpc.ServiceDesc{
 }
 
 func init() {
-	proto.RegisterFile("download_service.proto", fileDescriptor_download_service_27a97b505d50aaec)
+	proto.RegisterFile("download_service.proto", fileDescriptor_download_service_9db8895138dec550)
 }
 
-var fileDescriptor_download_service_27a97b505d50aaec = []byte{
+var fileDescriptor_download_service_9db8895138dec550 = []byte{
 	// 156 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0xe2, 0x12, 0x4b, 0xc9, 0x2f, 0xcf,
 	0xcb, 0xc9, 0x4f, 0x4c, 0x89, 0x2f, 0x4e, 0x2d, 0x2a, 0xcb, 0x4c, 0x4e, 0xd5, 0x2b, 0x28, 0xca,


### PR DESCRIPTION
downloader of s3manager used too much memory so we needed to use GetObject and define ranges instead.

Signed-off-by: Omri Shtamberger <omrishtam@gmail.com>